### PR TITLE
Remove stray JavaScript snippet from sendOrders handler

### DIFF
--- a/distrinic/application/controllers/Order.php
+++ b/distrinic/application/controllers/Order.php
@@ -212,24 +212,6 @@ class Order extends CI_Controller
                     echo $response->message;
                 } else {
                     echo $res; // "Hubo un error. Intente nuevamente";
-
-                //a//07-10-2025
-                $.post('<?= site_url("order/sendOrders"); ?>', {})
-                .done(function(resp){
-                    console.log('OK:', resp);
-                    // mostrar msj OK en el modal
-                })
-                .fail(function(xhr){
-                    console.error('Fallo:', xhr.status, xhr.responseText);
-                    // mostrar xhr.responseText en un <pre> del modal
-                    $('#resultado').html(
-                    '<pre style="white-space:pre-wrap">'+
-                    $('<div>').text(xhr.responseText).html()+'</pre>'
-                    );
-                });
-                //a//fin 07-10-2025
-
-                    
                 }
             }
         } else {


### PR DESCRIPTION
## Summary
- remove an inadvertent JavaScript snippet embedded in the PHP sendOrders controller logic
- ensure the error branch simply returns the webservice response message

## Testing
- php -l AppWeb_Distrinic/distrinic/application/controllers/Order.php

------
https://chatgpt.com/codex/tasks/task_e_68e5f5278454832cb7b831819059fc8b